### PR TITLE
Update Issue/321

### DIFF
--- a/src/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandler.java
+++ b/src/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandler.java
@@ -32,9 +32,17 @@ public class AsepriteHandler {
   /**
    * Thrown to indicate error when importing Aseprite JSON format.
    */
-  public static class ImportAnimationException extends Error {
+  public static class ImportAnimationException extends IOException {
     public ImportAnimationException(String message) {
       super(message);
+    }
+    
+    public ImportAnimationException(String message, Throwable cause) {
+      super(message, cause);
+    }
+    
+    public ImportAnimationException(Throwable cause) {
+      super(cause);
     }
   }
   
@@ -206,9 +214,17 @@ public class AsepriteHandler {
   /**
    * Error that is thrown by the export class
    */
-  public static class ExportAnimationException extends Error {
+  public static class ExportAnimationException extends IOException {
     public ExportAnimationException(String message) {
       super(message);
+    }
+    
+    public ExportAnimationException(String message, Throwable cause) {
+      super(message, cause);
+    }
+    
+    public ExportAnimationException(Throwable cause) {
+      super(cause);
     }
   }
   
@@ -217,8 +233,9 @@ public class AsepriteHandler {
    * This is the public accesible function and can/should be changed to fit into the UI.
    *
    * @param spritesheetResource the animation object to export
+   * @throws ExportAnimationException if the export fails
    */
-  public static String exportAnimation(SpritesheetResource spritesheetResource) {
+  public static String exportAnimation(SpritesheetResource spritesheetResource) throws ExportAnimationException {
     String json = createJson(spritesheetResource);
     return json;
   }
@@ -228,8 +245,9 @@ public class AsepriteHandler {
    *
    * @param spritesheetResource spritesheetResource object to export as json.
    * @return the json as a string.
+   * @throws ExportAnimationException if the export fails
    */
-  private static String createJson(SpritesheetResource spritesheetResource) {
+  private static String createJson(SpritesheetResource spritesheetResource) throws ExportAnimationException {
     Spritesheet spritesheet = Resources.spritesheets().load(spritesheetResource);
     assert spritesheet != null;
     int[] keyframes = Resources.spritesheets().getCustomKeyFrameDurations(spritesheet);

--- a/src/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandler.java
+++ b/src/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandler.java
@@ -267,19 +267,19 @@ public class AsepriteHandler {
       for (int j = 0; j < numCol; j++) {
         final int row = i;
         final int col = j;
-        Map<String, Integer> frame = new HashMap<>() {{
+        Map<String, Integer> frame = new HashMap<String, Integer>() {{
           put("x", (0 + col * frameWidth));
           put("y", (0 + row * frameHeight));
           put("w", frameWidth);
           put("h", frameHeight);
         }};
-        Map<String, Integer> spriteSourceSize = new HashMap<>() {{
+        Map<String, Integer> spriteSourceSize = new HashMap<String, Integer>() {{
           put("x", 0);
           put("y", 0);
           put("w", frameWidth);
           put("h", frameHeight);
         }};
-        Map<String, Integer> sourceSize = new HashMap<>() {{
+        Map<String, Integer> sourceSize = new HashMap<String, Integer>() {{
           put("w", frameWidth);
           put("h", frameHeight);
         }};
@@ -298,7 +298,7 @@ public class AsepriteHandler {
     // Build the meta object in the json
     int spritesheetWidth = frameWidth * numCol;
     int spritesheetHeight = frameHeight * numRows;
-    Map<String, Integer> size = new HashMap<>() {{
+    Map<String, Integer> size = new HashMap<String, Integer>() {{
       put("w", spritesheetWidth);
       put("h", spritesheetHeight);
     }};

--- a/src/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandler.java
+++ b/src/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandler.java
@@ -20,8 +20,6 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonObject;
 
 import de.gurkenlabs.litiengine.graphics.Spritesheet;
-import de.gurkenlabs.litiengine.graphics.animation.Animation;
-import de.gurkenlabs.litiengine.graphics.animation.KeyFrame;
 import de.gurkenlabs.litiengine.resources.Resources;
 import de.gurkenlabs.litiengine.resources.SpritesheetResource;
 

--- a/tests/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandlerTests.java
+++ b/tests/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandlerTests.java
@@ -48,8 +48,6 @@ public class AsepriteHandlerTests {
       fail(e.getMessage());
     } catch (IOException e) {
       fail(e.getMessage());
-    } catch (AsepriteHandler.ImportAnimationException e) {
-      fail(e.getMessage());
     }
   } 
 

--- a/tests/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandlerTests.java
+++ b/tests/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandlerTests.java
@@ -1,10 +1,8 @@
 package de.gurkenlabs.litiengine.graphics.animation;
 
-import java.io.File;
-import java.io.FileReader;
-
 import java.io.IOException;
 import java.io.FileNotFoundException;
+
 import java.awt.image.BufferedImage;
 
 import static org.junit.jupiter.api.Assertions.fail;

--- a/utiliti/src/de/gurkenlabs/utiliti/components/Editor.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/components/Editor.java
@@ -516,7 +516,7 @@ public class Editor extends Screen {
       }
       this.loadSpriteSheets(sprites, true);
   
-    } catch (AsepriteHandler.ImportAnimationException | IOException e) {
+    } catch (IOException e) {
       log.log(Level.SEVERE,  e.getMessage(), e);
     }
   }

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/AssetPanelItem.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/AssetPanelItem.java
@@ -486,7 +486,7 @@ public class AssetPanelItem extends JPanel {
             break;
           }
         }
-      } catch (AsepriteHandler.ExportAnimationException | IOException e) {
+      } catch (IOException e) {
         log.log(Level.SEVERE, e.getMessage(), e);
       }
     }


### PR DESCRIPTION
- Removes some unused imports,
- Import/Export Animation Exceptions subclass IOException instead of Error
- Fixes a build error

The build error was the following:

```
gamebuster@gamebuster-System-Product-Name:~/Desktop/Modding/LitiEngine$ ./gradlew build

> Task :compileJava FAILED
/home/gamebuster/Desktop/Modding/LitiEngine/src/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandler.java:270: error: cannot infer type arguments for HashMap<K,V>
        Map<String, Integer> frame = new HashMap<>() {{
                                                ^
  reason: cannot use '<>' with anonymous inner classes
  where K,V are type-variables:
    K extends Object declared in class HashMap
    V extends Object declared in class HashMap
/home/gamebuster/Desktop/Modding/LitiEngine/src/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandler.java:276: error: cannot infer type arguments for HashMap<K,V>
        Map<String, Integer> spriteSourceSize = new HashMap<>() {{
                                                           ^
  reason: cannot use '<>' with anonymous inner classes
  where K,V are type-variables:
    K extends Object declared in class HashMap
    V extends Object declared in class HashMap
/home/gamebuster/Desktop/Modding/LitiEngine/src/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandler.java:282: error: cannot infer type arguments for HashMap<K,V>
        Map<String, Integer> sourceSize = new HashMap<>() {{
                                                     ^
  reason: cannot use '<>' with anonymous inner classes
  where K,V are type-variables:
    K extends Object declared in class HashMap
    V extends Object declared in class HashMap
/home/gamebuster/Desktop/Modding/LitiEngine/src/de/gurkenlabs/litiengine/graphics/animation/AsepriteHandler.java:301: error: cannot infer type arguments for HashMap<K,V>
    Map<String, Integer> size = new HashMap<>() {{
                                           ^
  reason: cannot use '<>' with anonymous inner classes
  where K,V are type-variables:
    K extends Object declared in class HashMap
    V extends Object declared in class HashMap
4 errors

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 552ms
3 actionable tasks: 2 executed, 1 up-to-date

```
